### PR TITLE
build: split out runtime libraries from main jar package

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,3 +44,24 @@ dependencies {
 tasks.withType<Test> {
 	useJUnitPlatform()
 }
+
+tasks.register<Delete>("cleanRuntimeLibraries") {
+	delete(layout.buildDirectory.dir("libs/lib"))
+}
+
+tasks.register<Copy>("copyRuntimeLibraries") {
+	from(configurations.compileClasspath)
+	into(layout.buildDirectory.dir("libs/lib"))
+	dependsOn("cleanRuntimeLibraries")
+}
+
+tasks.bootJar {
+	exclude("*.jar")
+	dependsOn("cleanRuntimeLibraries", "copyRuntimeLibraries")
+
+	manifest {
+		attributes(
+			"Class-Path" to configurations.runtimeClasspath.get().files.joinToString(" ") { "lib/${it.name}" }
+		)
+	}
+}


### PR DESCRIPTION
This may reduce the package size and make it easier to upload when somethings are changed.